### PR TITLE
Add sublime_text version selectors

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10,6 +10,7 @@
       "details": "https://github.com/colinta/zenburn",
       "releases": [
         {
+          "sublime_text": "*",
           "details": "https://github.com/colinta/zenburn/tags"
         }
       ]
@@ -289,6 +290,7 @@
       "labels": ["game"],
       "releases": [
         {
+          "sublime_text": "*",
           "details": "https://github.com/colinta/INDY500/tags"
         }
       ]


### PR DESCRIPTION
We require these now due to the confusion it caused in the past
