### PR TITLE
Properly rename ApacheConf

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -183,6 +183,7 @@
     },
     {
       "name": "ApacheConf",
+      "previous_names": ["ApacheConf.tmLanguage"],
       "description": "For htaccess and .conf files.  By GreyWyvern, with assist by radiosilence.  <http://www.sublimetext.com/forum/viewtopic.php?f=5&t=856>.",
       "author": "GreyWyvern and radiosilence",
       "details": "https://github.com/colinta/ApacheConf.tmLanguage",


### PR DESCRIPTION
When renaming a package, the old name needs to somehow reference the new one otherwise nobody would be able to make connection.

Otherwise this causes situations like this:

https://packagecontrol.io/browse/authors/GreyWyvern%20and%20radiosilence